### PR TITLE
Adding the Z value of the Left Slider Menu

### DIFF
--- a/src/Views/components/leftSlider.jsx
+++ b/src/Views/components/leftSlider.jsx
@@ -48,7 +48,7 @@ const LeftSlider = ({
     <>
       {/* Menu button - Uses fixed positioning, centered vertically */}
       <div
-        className={`fixed top-1/2 left-0 transform -translate-y-1/2 z-10 transition-transform duration-300 ${
+        className={`fixed top-1/2 left-0 transform -translate-y-1/2 z-20 transition-transform duration-300 ${
           isOpen ? '-translate-x-full' : 'translate-x-0' // Handles sliding in/out
         }`}
       >


### PR DESCRIPTION
This pull request includes a change to the `LeftSlider` component in the `src/Views/components/leftSlider.jsx` file. The change modifies the z-index value of the menu button to ensure it appears above other elements when it is open.

* [`src/Views/components/leftSlider.jsx`](diffhunk://#diff-9cabc90bff6821b2516655ec13e7db4792e9ba01040926a980c7e243a5584c86L51-R51): Changed the z-index value from `z-10` to `z-20` in the `LeftSlider` component to ensure the menu button appears above other elements when open.